### PR TITLE
Fix IE8 bug: 'class' has to be quoted

### DIFF
--- a/lib/jquery.raty-fa.js
+++ b/lib/jquery.raty-fa.js
@@ -181,7 +181,7 @@
     }, _createCancel: function() {
       var that   = $(this),
           icon   = this.opt.cancelOff,
-          cancel = $('<i />', { class: icon, title: this.opt.cancelHint });
+          cancel = $('<i />', { 'class': icon, title: this.opt.cancelHint });
 
       if (this.opt.cancelPlace == 'left') {
         that.prepend('&#160;').prepend(cancel);
@@ -201,7 +201,7 @@
 
         icon = this.opt[icon];
 
-        $('<i />', { class : icon, title: title, 'data-score': i }).appendTo(this);
+        $('<i />', { 'class' : icon, title: title, 'data-score': i }).appendTo(this);
 
         if (this.opt.space) {
           that.append((i < this.opt.number) ? '&#160;' : '');


### PR DESCRIPTION
'class' is considered as reserved keyword in IE8 and has to be quoted.
