### PR TITLE
fix: users can set default `score` to 0

### DIFF
--- a/lib/jquery.raty-fa.js
+++ b/lib/jquery.raty-fa.js
@@ -57,7 +57,7 @@
       this.opt.targetType = 'score';
       this.opt.half       = true;
     }, _apply: function(score) {
-      if (score && score > 0) {
+      if (typeof score !== 'undefined' && score >= 0) {
         score = methods._between(score, 0, this.opt.number);
         this.score.val(score);
       }


### PR DESCRIPTION
score with value 0 is meaningful in a typical rating scale
